### PR TITLE
Some fixes about Shock(Tesla) Trooper

### DIFF
--- a/mods/ra2/rules/soviet-infantry.yaml
+++ b/mods/ra2/rules/soviet-infantry.yaml
@@ -94,10 +94,11 @@ shk:
 		Queue: Infantry
 		BuildAtProductionType: Infantry
 		Prerequisites: ~nahand
+		BuildPaletteOrder: 30
 	Valued:
 		Cost: 500
 	Tooltip:
-		Name: Shock Trooper
+		Name: Tesla Trooper
 		Description: Special armored unit using electricity.\n  Strong vs Infantry, Light armor\n  Weak vs Tanks, Aircraft\nSpecial ability: Charge tesla coils (3 Tesla Troopers required)
 	Selectable:
 		Bounds: 20, 30, 0, -11

--- a/mods/ra2/weapons/soviet-infantry.yaml
+++ b/mods/ra2/weapons/soviet-infantry.yaml
@@ -222,6 +222,8 @@ ElectricBolt:
 			Steel: 50
 			Concrete: 50
 		DamageTypes: ElectroDeath
+	Warhead@2Eff: CreateEffect
+		Explosion: tesla_impact
 
 ElectricBoltE:
 	Range: 5c0
@@ -243,6 +245,8 @@ ElectricBoltE:
 			Steel: 50
 			Concrete: 50
 		DamageTypes: ElectroDeath
+	Warhead@2Eff: CreateEffect
+		Explosion: tesla_impact
 
 IvanBomber:
 	ReloadDelay: 50


### PR DESCRIPTION
Fixes their name, adds missing `BuildPaletteOrder:`, ~~removes unrequired (possibly from copy paste from RA1 Mod) `BuildAtProductionType:`~~ and adds tesla impact to its weapon anim.

As tesla impact is added at #54 first it should be merged.
