### PR TITLE
Fix Defences' wrong Inherits:

### DIFF
--- a/mods/ra2/rules/allied-structures.yaml
+++ b/mods/ra2/rules/allied-structures.yaml
@@ -455,7 +455,7 @@ gawall:
 		Type: Concrete
 
 gapill:
-	Inherits: ^Building
+	Inherits: ^SupportBuilding
 	Buildable:
 		Queue: Support
 		BuildPaletteOrder: 20
@@ -641,7 +641,7 @@ gaspysat:
 	RequiresPower:
 
 gagap:
-	Inherits: ^Building
+	Inherits: ^SupportBuilding
 	Valued:
 		Cost: 1000
 	Tooltip:
@@ -726,7 +726,7 @@ gacsph:
 		Sequence: idle-dome
 
 atesla:
-	Inherits: ^Building
+	Inherits: ^SupportBuilding
 	Buildable:
 		Queue: Support
 		BuildPaletteOrder: 35

--- a/mods/ra2/rules/soviet-structures.yaml
+++ b/mods/ra2/rules/soviet-structures.yaml
@@ -614,7 +614,7 @@ naflak:
 		Amount: -50
 
 tesla:
-	Inherits: ^Building
+	Inherits: ^SupportBuilding
 	Buildable:
 		Queue: Support
 		BuildPaletteOrder: 30


### PR DESCRIPTION
It was making them capturable and give buildable area. ~~Not sure about is SpySat and Psychic Sensor Capturable in orginal YR but i didn't changed them.~~

I looked, they are capturable.
