### PR TITLE
Remove AnnounceOnKill from Kirov Airship

### DIFF
--- a/mods/ra2/audio/voices.yaml
+++ b/mods/ra2/audio/voices.yaml
@@ -269,7 +269,6 @@ KirovVoice:
 		Attack: vkirata, vkiratb, vkiratc, vkiratd
 		Feedback: vkirfea, vkirfeb, vkirfec
 		Die: vkirdia, vkirdib, vkirdic, vkirdid
-		Kill: vkirdia, vkirdib, vkirdic, vkirdid
 
 DemolitionTruckVoice:
 	DefaultVariant: .wav

--- a/mods/ra2/rules/aircraft.yaml
+++ b/mods/ra2/rules/aircraft.yaml
@@ -41,7 +41,6 @@ zep:
 		Weapon: UnitExplode
 		Chance: 75
 	AnnounceOnBuild:
-	AnnounceOnKill:
 	Voiced:
 		VoiceSet: KirovVoice
 #	SpawnActorOnDeath:


### PR DESCRIPTION
Not sure why even it had this. It was playing death sound when it kills someone.
